### PR TITLE
inbo_rapport_2015: add pandoc_args argument

### DIFF
--- a/R/inbo_rapport_2015.R
+++ b/R/inbo_rapport_2015.R
@@ -33,6 +33,7 @@ inbo_rapport_2015 <- function(
   lang = "dutch",
   keep_tex = FALSE,
   fig_crop = TRUE,
+  pandoc_args = NULL,
   ...
 ){
   floatbarrier <- match.arg(floatbarrier)
@@ -46,6 +47,7 @@ inbo_rapport_2015 <- function(
     pandoc_variable_arg("documentclass", "report"),
     pandoc_variable_arg("lang", lang)
   )
+  args <- c(args, pandoc_args)
   if (!missing(natbib)) {
     args <- c(args, "--natbib", pandoc_variable_arg("natbibfile", natbib))
   } else {


### PR DESCRIPTION
This allows further pandoc functionality from within the INBO report template, such as adding filters to let pandoc work with Zotero. This conforms to [the way it is done in the pdf_document output format](http://rmarkdown.rstudio.com/pdf_document_format.html#pandoc_arguments) in rmarkdown. @ThierryO 
