### PR TITLE
inbo_rapport_2015: add pandoc_args argument

### DIFF
--- a/R/inbo_rapport_2015.R
+++ b/R/inbo_rapport_2015.R
@@ -8,6 +8,7 @@
 #' @param keep_tex Keep the tex file. Defaults to FALSE.
 #' @param fig_crop \code{TRUE} to automatically apply the \code{pdfcrop} utility
 #'   (if available) to pdf figures
+#' @param pandoc_args Additional command line options to pass to pandoc
 #' @param ... extra parameters: see details
 #'
 #' @details

--- a/man/inbo_rapport_2015.Rd
+++ b/man/inbo_rapport_2015.Rd
@@ -6,7 +6,7 @@
 \usage{
 inbo_rapport_2015(subtitle, reportnr, ordernr, floatbarrier = c(NA, "section",
   "subsection", "subsubsection"), natbib, lang = "dutch", keep_tex = FALSE,
-  fig_crop = TRUE, ...)
+  fig_crop = TRUE, pandoc_args = NULL, ...)
 }
 \arguments{
 \item{subtitle}{An optional subtitle}
@@ -25,6 +25,8 @@ inbo_rapport_2015(subtitle, reportnr, ordernr, floatbarrier = c(NA, "section",
 
 \item{fig_crop}{\code{TRUE} to automatically apply the \code{pdfcrop} utility
 (if available) to pdf figures}
+
+\item{pandoc_args}{Additional command line options to pass to pandoc}
 
 \item{...}{extra parameters: see details}
 }


### PR DESCRIPTION
This allows further pandoc functionality from within the INBO report template, such as adding filters to let pandoc work with Zotero. This conforms to [the way it is done in the `pdf_document` output format](http://rmarkdown.rstudio.com/pdf_document_format.html#pandoc_arguments) in `rmarkdown`. @ThierryO
