### PR TITLE
Update inbo.csl to match state at CSL repository

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,4 @@ Dockerfile
 _pkgdown.yml
 pkgdown
 docs
+^data-raw$

--- a/R/inbo_handouts.R
+++ b/R/inbo_handouts.R
@@ -42,7 +42,8 @@ inbo_handouts <- function(
 
   extra <- list(...)
   codesize <- match.arg(codesize)
-  csl <- system.file("inbo.csl", package = "INBOmd")
+  csl <- system.file("research-institute-for-nature-and-forest.csl",
+                     package = "INBOmd")
   template <- system.file("pandoc/inbo_beamer.tex", package = "INBOmd")
   args <- c(
     "--slide-level", as.character(slide_level),

--- a/R/inbo_poster.R
+++ b/R/inbo_poster.R
@@ -48,7 +48,8 @@ inbo_poster <- function(
   codesize <- match.arg(codesize)
 
   template <- system.file("pandoc/inbo_poster.tex", package = "INBOmd")
-  csl <- system.file("inbo.csl", package = "INBOmd")
+  csl <- system.file("research-institute-for-nature-and-forest.csl",
+                     package = "INBOmd")
 
   args <- c(
     "--template", template,

--- a/R/inbo_rapport.R
+++ b/R/inbo_rapport.R
@@ -57,7 +57,8 @@ inbo_rapport <- function(
   codesize <- match.arg(codesize)
 
   template <- system.file("pandoc/inbo_rapport.tex", package = "INBOmd")
-  csl <- system.file("inbo.csl", package = "INBOmd")
+  csl <- system.file("research-institute-for-nature-and-forest.csl",
+                     package = "INBOmd")
   citation_package <- match.arg(citation_package)
 
   args <- c(

--- a/R/inbo_slides.R
+++ b/R/inbo_slides.R
@@ -64,7 +64,8 @@ inbo_slides <- function(
   assert_that(noNA(flandersfont)) #nolint
 
   codesize <- match.arg(codesize)
-  csl <- system.file("inbo.csl", package = "INBOmd")
+  csl <- system.file("research-institute-for-nature-and-forest.csl",
+                     package = "INBOmd")
   template <- system.file("pandoc/inbo_beamer.tex", package = "INBOmd")
   args <- c(
     "--slide-level", as.character(slide_level),

--- a/R/inbo_verslag.R
+++ b/R/inbo_verslag.R
@@ -37,7 +37,8 @@ inbo_verslag <- function(
   codesize <- match.arg(codesize)
 
   template <- system.file("pandoc/inbo_verslag.tex", package = "INBOmd")
-  csl <- system.file("inbo.csl", package = "INBOmd")
+  csl <- system.file("research-institute-for-nature-and-forest.csl",
+                     package = "INBOmd")
   args <- c(
     "--template", template,
     pandoc_variable_arg("present", present),

--- a/R/inbo_zending.R
+++ b/R/inbo_zending.R
@@ -43,7 +43,8 @@ inbo_zending <- function(
   codesize <- match.arg(codesize)
 
   template <- system.file("pandoc/inbo_zending.tex", package = "INBOmd")
-  csl <- system.file("inbo.csl", package = "INBOmd")
+  csl <- system.file("research-institute-for-nature-and-forest.csl",
+                     package = "INBOmd")
   args <- c(
     "--template", template,
     pandoc_variable_arg("conference", conference),

--- a/data-raw/import_external_data.R
+++ b/data-raw/import_external_data.R
@@ -1,0 +1,5 @@
+# Download the CSL file from the Zotero repository
+curl::curl_download(
+  "http://www.zotero.org/styles/research-institute-for-nature-and-forest",
+  "inst/research-institute-for-nature-and-forest.csl"
+)

--- a/inst/inbo.csl
+++ b/inst/inbo.csl
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never">
   <info>
-    <title>Research Institute for Nature and Forest</title>
+    <title>Research Institute for Nature and Forest (Instituut voor Natuur- en Bosonderzoek)</title>
     <title-short>INBO</title-short>
-    <id>http://www.zotero.org/styles/inbo</id>
+    <id>http://www.zotero.org/styles/research-institute-for-nature-and-forest</id>
+    <link href="http://www.zotero.org/styles/research-institute-for-nature-and-forest" rel="self"/>
     <author>
       <name>Maarten Stevens</name>
       <uri>http://www.mendeley.com/profiles/maarten-stevens/</uri>
@@ -18,9 +19,7 @@
     </contributor>
     <category citation-format="author-date"/>
     <category field="biology"/>
-    <category field="generic-base"/>
     <updated>2019-08-01T00:00:00</updated>
-    <link href="http://www.zotero.org/styles/inbo" rel="self"/>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -74,7 +73,11 @@
   <macro name="author">
     <names variable="author">
       <name and="symbol" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="all" sort-separator=" "/>
+<<<<<<< HEAD
       <label form="short" prefix=" (" suffix=")"/>
+=======
+      <label form="short" prefix=" (" suffix=")" text-case="capitalize-first"/>
+>>>>>>> 572807d... Update of inbo.csl to its state at the CSL repository *
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>

--- a/inst/inbo.csl
+++ b/inst/inbo.csl
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never">
   <info>
-    <title>Research Institute for Nature and Forest (Instituut voor Natuur- en Bosonderzoek)</title>
+    <title>Research Institute for Nature and Forest</title>
     <title-short>INBO</title-short>
-    <id>http://www.zotero.org/styles/research-institute-for-nature-and-forest</id>
-    <link href="http://www.zotero.org/styles/research-institute-for-nature-and-forest" rel="self"/>
+    <id>http://www.zotero.org/styles/inbo</id>
     <author>
       <name>Maarten Stevens</name>
       <uri>http://www.mendeley.com/profiles/maarten-stevens/</uri>
@@ -19,7 +18,9 @@
     </contributor>
     <category citation-format="author-date"/>
     <category field="biology"/>
+    <category field="generic-base"/>
     <updated>2019-08-01T00:00:00</updated>
+    <link href="http://www.zotero.org/styles/inbo" rel="self"/>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">

--- a/inst/research-institute-for-nature-and-forest.csl
+++ b/inst/research-institute-for-nature-and-forest.csl
@@ -25,22 +25,12 @@
   <locale xml:lang="en">
     <terms>
       <term name="in">In</term>
-      <term name="editor" form="short">
-        <single>ed.</single>
-        <multiple>eds.</multiple>
-      </term>
-      <term name="no date" form="short">s.d.</term>
     </terms>
   </locale>
   <locale xml:lang="nl">
     <terms>
       <term name="in">In</term>
       <term name="et-al">et al.</term>
-      <term name="editor" form="short">
-        <single>ed.</single>
-        <multiple>eds.</multiple>
-      </term>
-      <term name="no date" form="short">s.d.</term>
     </terms>
   </locale>
   <macro name="container">
@@ -48,8 +38,8 @@
       <if type="chapter paper-conference" match="any">
         <text term="in" prefix=". " suffix=": "/>
         <names variable="editor translator" delimiter=", " suffix=". ">
-          <name and="symbol" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="all" sort-separator=" "/>
-          <label text-case="lowercase" form="short" prefix=" (" suffix=")"/>
+          <name delimiter-precedes-last="always" initialize-with="." name-as-sort-order="all" sort-separator=" "/>
+          <label text-case="lowercase" prefix=" (" suffix=")"/>
         </names>
         <group delimiter=", ">
           <text variable="container-title"/>
@@ -73,11 +63,7 @@
   <macro name="author">
     <names variable="author">
       <name and="symbol" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="all" sort-separator=" "/>
-<<<<<<< HEAD
-      <label form="short" prefix=" (" suffix=")"/>
-=======
       <label form="short" prefix=" (" suffix=")" text-case="capitalize-first"/>
->>>>>>> 572807d... Update of inbo.csl to its state at the CSL repository *
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -107,7 +93,7 @@
     <choose>
       <if type="webpage">
         <group delimiter=" ">
-          <text value="URL" suffix=":"/>
+          <text value="URL"/>
           <text variable="URL"/>
           <group prefix="(" suffix=").">
             <text term="accessed" suffix=" "/>
@@ -224,7 +210,7 @@
   </macro>
   <macro name="url">
     <choose>
-      <if type="webpage" variable="DOI" match="none">
+      <if type="webpage" match="none">
         <choose>
           <if match="any" variable="URL">
             <text value="URL" suffix=": "/>

--- a/inst/research-institute-for-nature-and-forest.csl
+++ b/inst/research-institute-for-nature-and-forest.csl
@@ -19,7 +19,7 @@
     </contributor>
     <category citation-format="author-date"/>
     <category field="biology"/>
-    <updated>2019-08-01T00:00:00</updated>
+    <updated>2019-08-08T03:58:17+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">


### PR DESCRIPTION
This PR updates inbo.csl to the state of research-institute-for-nature-and-forest.csl in the CSL repository at commit [bc20f1c](https://github.com/citation-style-language/styles/commit/bc20f1c060f573e112d289ed7c4194be46b7616b).