### PR TITLE
Add french styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 .Rhistory
 .Rproj.user
 .Ruserdata
-*.html
 *.log
 *.synctex.gz
 *.toc

--- a/R/ebook.R
+++ b/R/ebook.R
@@ -33,7 +33,7 @@ ebook <- function() {
     msg = "Use style: Vlaanderen when the language is nl"
   )
   assert_that(
-    style == "Flanders" || lang != "en",
+    style == "Flanders" || !lang %in% c("en", "fr"),
     msg = "Use style: Flanders when the language is not nl"
   )
 

--- a/R/gitbook.R
+++ b/R/gitbook.R
@@ -24,7 +24,7 @@ gitbook <- function() {
     has_name(fm, "lang"), fm$lang, ifelse(style == "Flanders", "en", "nl")
   )
   assert_that(length(lang) == 1)
-  languages <- c(nl = "dutch", en = "english")
+  languages <- c(nl = "dutch", en = "english", fr = "french")
   assert_that(
     lang %in% names(languages),
     msg = paste(
@@ -37,7 +37,7 @@ gitbook <- function() {
     msg = "Use style: Vlaanderen when the language is nl"
   )
   assert_that(
-    style == "Flanders" || lang != "en",
+    style == "Flanders" || lang %in% c("en", "fr"),
     msg = "Use style: Flanders when the language is not nl"
   )
   split_by <- ifelse(has_name(fm, "split_by"), fm$split_by, "chapter+number")

--- a/R/report.R
+++ b/R/report.R
@@ -70,12 +70,15 @@ report <- function(
   csl <- system.file("research-institute-for-nature-and-forest.csl",
                      package = "INBOmd")
 
+  style <- ifelse(style == "Flanders" & lang == "fr", "Flandre", style)
+
   args <- c(
     "--template", template,
     pandoc_variable_arg("documentclass", "report"),
     switch(
       style,
       Flanders = pandoc_variable_arg("style", "flanders_report"),
+      Flandre = pandoc_variable_arg("style", "flandre_report"),
       Vlaanderen = pandoc_variable_arg("style", "vlaanderen_report"),
       INBO = pandoc_variable_arg("style", "inbo_report")
     ),

--- a/inst/local_tex/tex/latex/inborapport_2015/flandre_report.sty
+++ b/inst/local_tex/tex/latex/inborapport_2015/flandre_report.sty
@@ -13,7 +13,7 @@
 \pagestyle{fancy}
 \fancyhead{}
 \fancyfoot{}
-\fancyfoot[LO, RE]{{\color{main.colour}\fontsize{\fontsizefooter}{\fontsizefooterinter}\selectfont \mainColourURL{\href{https://www.vlaanderen.be/en}{www.vlaanderen.be}}}}
+\fancyfoot[LO, RE]{{\color{main.colour}\fontsize{\fontsizefooter}{\fontsizefooterinter}\selectfont \mainColourURL{\href{https://www.vlaanderen.be/fr}{www.vlaanderen.be}}}}
 \fancyfoot[LE, RO]{{\color{main.colour}\fontsize{\fontsizefooter}{\fontsizefooterinter}\selectfont \pagename \textbf{ \thepage} / \textbf{\pageref*{LastPage}}}}
 \fancyfoot[CE, CO]{{\color{main.colour}\fontsize{\fontsizefooter}{\fontsizefooterinter}\selectfont \mainColourURL{\@doi}}}
 \renewcommand{\footrule}{\vbox to 8pt{\hbox
@@ -24,7 +24,7 @@ to\headwidth{\color{main.colour}\fontsize{\fontsizefooter}{\fontsizefooterinter}
 \fancypagestyle{plain}{%
   \fancyhead{}
   \fancyfoot{}
-  \fancyfoot[LO, RE]{{\color{main.colour}\fontsize{\fontsizefooter}{\fontsizefooterinter}\selectfont \mainColourURL{\href{https://www.vlaanderen.be/en}{www.vlaanderen.be}}}}
+  \fancyfoot[LO, RE]{{\color{main.colour}\fontsize{\fontsizefooter}{\fontsizefooterinter}\selectfont \mainColourURL{\href{https://www.vlaanderen.be/fr}{www.vlaanderen.be}}}}
   \fancyfoot[CE, CO]{{\color{main.colour}\fontsize{\fontsizefooter}{\fontsizefooterinter}\selectfont \mainColourURL{\@doi}}}
   \fancyfoot[LE, RO]{{\color{main.colour}\fontsize{\fontsizefooter}{\fontsizefooterinter}\selectfont \pagename \textbf{ \thepage} / \textbf{\pageref*{LastPage}}}}
   \renewcommand{\headrulewidth}{0pt}

--- a/inst/local_tex/tex/latex/inborapport_2015/flandre_report.sty
+++ b/inst/local_tex/tex/latex/inborapport_2015/flandre_report.sty
@@ -1,0 +1,43 @@
+%
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesPackage{flanders_report}
+
+\RequirePackage{flanders_report_generic}
+\titlelogo{\vspace{17mm}}
+\alertlogo{alert.eps}
+\examplelogo{example.eps}
+
+% definition of colour scheme
+\RequirePackage{flanderscolours}
+
+\pagestyle{fancy}
+\fancyhead{}
+\fancyfoot{}
+\fancyfoot[LO, RE]{{\color{main.colour}\fontsize{\fontsizefooter}{\fontsizefooterinter}\selectfont \mainColourURL{\href{https://www.vlaanderen.be/en}{www.vlaanderen.be}}}}
+\fancyfoot[LE, RO]{{\color{main.colour}\fontsize{\fontsizefooter}{\fontsizefooterinter}\selectfont \pagename \textbf{ \thepage} / \textbf{\pageref*{LastPage}}}}
+\fancyfoot[CE, CO]{{\color{main.colour}\fontsize{\fontsizefooter}{\fontsizefooterinter}\selectfont \mainColourURL{\@doi}}}
+\renewcommand{\footrule}{\vbox to 8pt{\hbox
+to\headwidth{\color{main.colour}\fontsize{\fontsizefooter}{\fontsizefooterinter}\selectfont\leaders\hbox{/}\hfill}\vss}}
+\renewcommand{\headrulewidth}{0pt}
+\renewcommand{\footrulewidth}{0pt}
+
+\fancypagestyle{plain}{%
+  \fancyhead{}
+  \fancyfoot{}
+  \fancyfoot[LO, RE]{{\color{main.colour}\fontsize{\fontsizefooter}{\fontsizefooterinter}\selectfont \mainColourURL{\href{https://www.vlaanderen.be/en}{www.vlaanderen.be}}}}
+  \fancyfoot[CE, CO]{{\color{main.colour}\fontsize{\fontsizefooter}{\fontsizefooterinter}\selectfont \mainColourURL{\@doi}}}
+  \fancyfoot[LE, RO]{{\color{main.colour}\fontsize{\fontsizefooter}{\fontsizefooterinter}\selectfont \pagename \textbf{ \thepage} / \textbf{\pageref*{LastPage}}}}
+  \renewcommand{\headrulewidth}{0pt}
+  \renewcommand{\footrulewidth}{0pt}
+}
+
+\fancypagestyle{cover}{%
+  \fancyhead{}
+  \fancyfoot{}
+  \fancyfoot[L]{\includegraphics[height = 10mm, keepaspectratio]{vlaanderen-en-naakt}}
+  \renewcommand{\headrulewidth}{0pt}
+  \renewcommand{\footrulewidth}{0pt}
+  \renewcommand{\footrule}{\vbox to 0pt{\hbox
+  to\headwidth{\hbox{}\hfill}\vss}}
+  \setlength{\footskip}{32.1pt}
+}

--- a/inst/template/report_fr.epub3
+++ b/inst/template/report_fr.epub3
@@ -96,19 +96,19 @@ $if(titlepage)$
   <h1 class = "missing">!!!! MISSING: reviewer !!!!</h1>
   $endif$
 
-  <p>The Research Institute for Nature and Forest (INBO) is an independent research institute of the Flemish government. Through applied scientific research, open data and knowledge, integration and disclosure, it underpins and evaluates biodiversity policy and management.
+  <p> l'Institut de Recherche des Forêts et de la Nature ('Instituut voor Natuur- en Bosonderzoek', INBO) est un institut de recherche indépendant du gouvernement flamand. Grâce à la recherche scientifique appliquée, aux données ouvertes et connaissances, à l'intégration et à la divulgation, elle étaye et évalue la politique et la gestion de la biodiversité.
 
-  <p><b>Location:</b><br>
+  <p><b>Emplacement:</b><br>
   $if(geraardsbergen)$
-  INBO Geraardsbergen<br>Gaverstraat 4, 9500 Geraardsbergen, Belgium
+  INBO Geraardsbergen<br>Gaverstraat 4, 9500 Geraardsbergen (Grammont), Belgique
   $else$
-  INBO Brussels<br>VAC Brussel - Herman Teirlinck, Havenlaan 88 bus 73, 1000 Brussels, Belgium
+  INBO Bruxelles<br>VAC Brussel - Herman Teirlinck, Havenlaan 88 bus 73, 1000 Bruxelles, Belgique
   $endif$
   <br><a href="https://www.vlaanderen.be/inbo/en-gb">https://www.vlaanderen.be/inbo/en-gb</a>
 
   <p><b>e-mail:</b><br><a class="author_email" href="mailto:#">$if(corresponding)$$corresponding$$else$info@inbo.be$endif$</a>
 
-  <p><b>Way of quoting:</b><br>
+  <p><b>Citation recommandée:</b><br>
   $if(shortauthor)$
     $shortauthor$
   $else$
@@ -119,7 +119,7 @@ $if(titlepage)$
   $else$
     <h1 class = "missing">!!!! MISSING: year !!!!</h1>
   $endif$
-  $title$$if(subtitle)$. $substitle$$endif$. Reports of the Research Institute for Nature and Forest
+  $title$$if(subtitle)$. $substitle$$endif$. Rapports de l'Institut de Recherche des Forêts et de la Nature
   $if(year)$
     $year$
   $endif$
@@ -128,7 +128,7 @@ $if(titlepage)$
   $else$
     <h1 class = "missing">!!!! MISSING: reportnr !!!!</h1>
   $endif$
-  Research Institute for Nature and Forest, Brussels. DOI:
+  l'Institut de Recherche des Forêts et de la Nature, Bruxelles. DOI:
   $if(doi)$
     <a class="doi" href="#">$doi$</a>
   $else$
@@ -150,16 +150,16 @@ $if(titlepage)$
   </b><br>
   <b>ISSN: 1782‐9054</b>
 
-  <p><b>Responsible publisher:</b><br>Maurice Hoffmann
+  <p><b>Éditeur responsable:</b><br>Maurice Hoffmann
 
   $if(cover_description)$
-    <p><b>Foto cover:</b><br>$cover_description$
+    <p><b>Photo de couverture:</b><br>$cover_description$
   $else$
     <h1 class = "missing">!!!! MISSING: cover_description !!!!</h1>
   $endif$
 
   $if(client)$
-  <p><b>This study was commissioned by:</b><br>
+  <p><b>Cette étude a été commandée par:</b><br>
      $for(client)$
         $client$
      $sep$ <br>
@@ -167,14 +167,14 @@ $if(titlepage)$
   $endif$
 
   $if(cooperation)$
-  <p><b>This study was conducted in collaboration with:</b><br>
+  <p><b>Cette étude a été menée en collaboration avec:</b><br>
      $for(cooperation)$
         $cooperation$
      $sep$ <br>
      $endfor$
   $endif$
 
-  <p><a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="../fonts/cc-by.svg" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
+  <p><a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="../fonts/cc-by.svg" /></a><br />Ce rapport est sous license <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
 </section>
 $else$
 $if(coverpage)$

--- a/inst/template/report_fr.epub3
+++ b/inst/template/report_fr.epub3
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="https://www.idpf.org/2007/ops"$if(lang)$ xml:lang="$lang$"$endif$>
+<head>
+  <meta charset="utf-8" />
+  <meta name="generator" content="pandoc" />
+  <title>$pagetitle$</title>
+  <style type="text/css">
+      code{white-space: pre-wrap;}
+      span.smallcaps{font-variant: small-caps;}
+      span.underline{text-decoration: underline;}
+      div.column{display: inline-block; vertical-align: top; width: 50%;}
+$if(quotes)$
+      q { quotes: "“" "”" "‘" "’"; }
+$endif$
+  </style>
+$if(highlighting-css)$
+  <style type="text/css">
+$highlighting-css$
+  </style>
+$endif$
+$for(css)$
+  <link rel="stylesheet" type="text/css" href="$css$" />
+$endfor$
+$for(header-includes)$
+  $header-includes$
+$endfor$
+</head>
+<body$if(coverpage)$ id="cover"$endif$$if(body-type)$ epub:type="$body-type$"$endif$>
+$if(titlepage)$
+<section epub:type="titlepage" class="titlepage">
+  <h1 class="title">$title$</h1>
+  $if(subtitle)$
+  <h2 class="subtitle">$subtitle$</h2>
+  $endif$
+  $for(author)$
+    $if(author.name)$
+      <h3 class="author">$if(author.firstname)$$author.firstname$ $endif$$author.name$
+      $if(author.orcid)$
+        <a href="https://orcid.org/$author.orcid$">
+        <img alt="ORCID logo" src="https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png" width="16" height="16" />
+        $author.orcid$
+        </a>
+      $endif$
+      </h3>
+      $if(author.affiliation)$
+        <address class="author_afil">
+        $author.affiliation$
+        $if(author.email)$
+          <br><a class="author_email" href="mailto:#">$author.email$</a>
+        $endif$
+        </address>
+      $else$
+        $if(author.email)$
+          <address class="author_afil">
+          <a class="author_email" href="mailto:#">$author.email$</a>
+          </address>
+        $endif$
+      $endif$
+    $else$
+      <h3 class="author">$author$</h3>
+    $endif$
+  $endfor$
+  $if(date)$
+  <p class="date"><em>$date$</em></p>
+  $endif$
+  $if(doi)$
+  <h4><a class="doi" href="#">$doi$</a></h4>
+  $endif$
+  $if(ordernr)$
+  <h4 class ="ordernr">$ordernr$</h4>
+  $endif$
+  <h1>Colophon</h1>
+  $if(reviewer)$
+    <p><b>Reviewers:</b><br>
+    $for(reviewer)$
+      $if(reviewer.name)$
+        $if(reviewer.firstname)$
+          $reviewer.firstname$
+        $endif$
+        $reviewer.name$
+        $if(reviewer.orcid)$
+          <a href="https://orcid.org/$reviewer.orcid$">
+          <img alt="ORCID logo" src="https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png" width="16" height="16" />
+          $reviewer.orcid$
+          </a>
+        $endif$
+        $if(reviewer.email)$
+          <a class="reviewer_email" href="mailto:#">$reviewer.email$</a>
+        $endif$<br>
+      $else$
+        $reviewer$<br>
+      $endif$
+    $endfor$
+  $else$
+  <h1 class = "missing">!!!! MISSING: reviewer !!!!</h1>
+  $endif$
+
+  <p>The Research Institute for Nature and Forest (INBO) is an independent research institute of the Flemish government. Through applied scientific research, open data and knowledge, integration and disclosure, it underpins and evaluates biodiversity policy and management.
+
+  <p><b>Location:</b><br>
+  $if(geraardsbergen)$
+  INBO Geraardsbergen<br>Gaverstraat 4, 9500 Geraardsbergen, Belgium
+  $else$
+  INBO Brussels<br>VAC Brussel - Herman Teirlinck, Havenlaan 88 bus 73, 1000 Brussels, Belgium
+  $endif$
+  <br><a href="https://www.vlaanderen.be/inbo/en-gb">https://www.vlaanderen.be/inbo/en-gb</a>
+
+  <p><b>e-mail:</b><br><a class="author_email" href="mailto:#">$if(corresponding)$$corresponding$$else$info@inbo.be$endif$</a>
+
+  <p><b>Way of quoting:</b><br>
+  $if(shortauthor)$
+    $shortauthor$
+  $else$
+    <h1 class = "missing">!!!! MISSING: shortauthor !!!!</h1>
+  $endif$
+  $if(year)$
+    ($year$).
+  $else$
+    <h1 class = "missing">!!!! MISSING: year !!!!</h1>
+  $endif$
+  $title$$if(subtitle)$. $substitle$$endif$. Reports of the Research Institute for Nature and Forest
+  $if(year)$
+    $year$
+  $endif$
+  $if(reportnr)$
+    ($reportnr$).
+  $else$
+    <h1 class = "missing">!!!! MISSING: reportnr !!!!</h1>
+  $endif$
+  Research Institute for Nature and Forest, Brussels. DOI:
+  $if(doi)$
+    <a class="doi" href="#">$doi$</a>
+  $else$
+    <h1 class = "missing">!!!! MISSING: doi !!!!</h1>
+  $endif$
+
+  $if(depotnr)$
+    <p><b>$depotnr$</b><br>
+  $else$
+    <h1 class = "missing">!!!! MISSING: depotnr !!!!</h1>
+  $endif$
+  <b>Reports of the Research Institute for Nature and Forest
+  $if(year)$
+    $year$
+  $endif$
+  $if(reportnr)$
+    ($reportnr$)
+  $endif$
+  </b><br>
+  <b>ISSN: 1782‐9054</b>
+
+  <p><b>Responsible publisher:</b><br>Maurice Hoffmann
+
+  $if(cover_description)$
+    <p><b>Foto cover:</b><br>$cover_description$
+  $else$
+    <h1 class = "missing">!!!! MISSING: cover_description !!!!</h1>
+  $endif$
+
+  $if(client)$
+  <p><b>This study was commissioned by:</b><br>
+     $for(client)$
+        $client$
+     $sep$ <br>
+     $endfor$
+  $endif$
+
+  $if(cooperation)$
+  <p><b>This study was conducted in collaboration with:</b><br>
+     $for(cooperation)$
+        $cooperation$
+     $sep$ <br>
+     $endfor$
+  $endif$
+
+  <p><a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="../fonts/cc-by.svg" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
+</section>
+$else$
+$if(coverpage)$
+<div id="cover-image">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="100%" height="100%" viewBox="0 0 $cover-image-width$ $cover-image-height$" preserveAspectRatio="xMidYMid">
+<image width="$cover-image-width$" height="$cover-image-height$" xlink:href="../media/$cover-image$" />
+</svg>
+</div>
+$else$
+$for(include-before)$
+$include-before$
+$endfor$
+$body$
+$for(include-after)$
+$include-after$
+$endfor$
+$endif$
+$endif$
+</body>
+</html>

--- a/inst/template/report_fr.html
+++ b/inst/template/report_fr.html
@@ -1,0 +1,383 @@
+<!DOCTYPE html>
+<html $if(lang)$ lang="$lang$"$endif$>
+
+<head>
+
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>$if(title-prefix)$$title-prefix$ - $endif$$pagetitle$</title>
+  <meta name="description" content="$if(description)$$description$$else$$title$$endif$">
+  <meta name="generator" content="bookdown <!--bookdown:version--> and GitBook 2.6.7">
+
+  <meta property="og:title" content="$pagetitle$" />
+  <meta property="og:type" content="book" />
+  $if(url)$<meta property="og:url" content="$url$" />$endif$
+  $if(cover_image)$<meta property="og:image" content="$url$$cover_image$" />$endif$
+  $if(description)$<meta property="og:description" content="$description$" />$endif$
+  $if(github-repo)$<meta name="github-repo" content="$github-repo$" />$endif$
+
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="$pagetitle$" />
+  $if(twitter_handle)$<meta name="twitter:site" content="@$twitter_handle$" />$endif$
+  $if(description)$<meta name="twitter:description" content="$description$" />$endif$
+  $if(cover_image)$<meta name="twitter:image" content="$url$$cover_image$" />$endif$
+
+$for(author-meta)$
+<meta name="author" content="$author-meta$">
+$endfor$
+
+$if(institute-meta)$
+<meta name="institute" content="$institute-meta$">
+$endif$
+
+$if(date-meta)$
+<meta name="date" content="$date-meta$">
+$endif$
+
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black">
+  $if(apple-touch-icon)$<link rel="apple-touch-icon-precomposed" sizes="$if(apple-touch-icon-size)$$apple-touch-icon-size$x$apple-touch-icon-size$$else$152x152$endif$" href="$apple-touch-icon$">$endif$
+  $if(favicon)$<link rel="shortcut icon" href="$favicon$" type="image/x-icon">$endif$
+<!--bookdown:link_prev-->
+<!--bookdown:link_next-->
+$if(abstract)$
+<style type="text/css">
+p.abstract{
+  text-align: center;
+  font-weight: bold;
+}
+div.abstract{
+  margin: auto;
+  width: 90%;
+}
+</style>
+$endif$
+$for(header-includes)$
+$header-includes$
+$endfor$
+
+$if(highlightjs)$
+<style type="text/css">code{white-space: pre;}</style>
+<link rel="stylesheet"
+      href="$highlightjs$/$if(highlightjs-theme)$$highlightjs-theme$$else$default$endif$.css"
+      $if(html5)$$else$type="text/css" $endif$/>
+<script src="$highlightjs$/highlight.js"></script>
+<script type="text/javascript">
+if (window.hljs && document.readyState && document.readyState === "complete") {
+   window.setTimeout(function() {
+      hljs.initHighlighting();
+   }, 0);
+}
+</script>
+$endif$
+
+$if(highlighting-css)$
+<style type="text/css">
+$highlighting-css$
+</style>
+$endif$
+
+$for(css)$
+<link rel="stylesheet" href="$css$" $if(html5)$$else$type="text/css" $endif$/>
+$endfor$
+</head>
+
+<body>
+
+
+
+<!--bookdown:title:start-->
+$if(title)$
+  <div id="$idprefix$header">
+  $if(cover_image)$
+    <img src="$url$$cover_image$" alt = "$shortauthor$ ($year$) $title$">
+  $endif$
+  <h1 class="title">$title$</h1>
+  $if(subtitle)$
+  <h2 class="subtitle">$subtitle$</h2>
+  $endif$
+  $for(author)$
+    $if(author.name)$
+      <h3 class="author">$if(author.firstname)$$author.firstname$ $endif$$author.name$
+      $if(author.orcid)$
+        <a href="https://orcid.org/$author.orcid$">
+        <img alt="ORCID logo" src="https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png" width="16" height="16" />
+        $author.orcid$
+        </a>
+      $endif$
+      </h3>
+      $if(author.affiliation)$
+        <address class="author_afil">
+        $author.affiliation$
+        $if(author.email)$
+          <br><a class="author_email" href="mailto:#">$author.email$</a>
+        $endif$
+        </address>
+      $else$
+        $if(author.email)$
+          <address class="author_afil">
+          <a class="author_email" href="mailto:#">$author.email$</a>
+          </address>
+        $endif$
+      $endif$
+    $else$
+      <h3 class="author">$author$</h3>
+    $endif$
+  $endfor$
+  $if(date)$
+  <p class="date"><em>$date$</em></p>
+  $endif$
+  $if(doi)$
+  <h4><a class="doi" href="#">$doi$</a></h4>
+  $endif$
+  $if(ordernr)$
+  <h4 class ="ordernr">$ordernr$</h4>
+  $endif$
+  <h1>Colophon</h1>
+  $if(reviewer)$
+    <p><b>Reviewers:</b><br>
+    $for(reviewer)$
+      $if(reviewer.name)$
+        $if(reviewer.firstname)$
+          $reviewer.firstname$
+        $endif$
+        $reviewer.name$
+        $if(reviewer.orcid)$
+          <a href="https://orcid.org/$reviewer.orcid$">
+          <img alt="ORCID logo" src="https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png" width="16" height="16" />
+          $reviewer.orcid$
+          </a>
+        $endif$
+        $if(reviewer.email)$
+          <a class="reviewer_email" href="mailto:#">$reviewer.email$</a>
+        $endif$<br>
+      $else$
+        $reviewer$<br>
+      $endif$
+    $endfor$
+  $else$
+  <h1 class = "missing">!!!! MISSING: reviewer !!!!</h1>
+  $endif$
+
+  <p>The Research Institute for Nature and Forest (INBO) is an independent research institute of the Flemish government. Through applied scientific research, open data and knowledge, integration and disclosure, it underpins and evaluates biodiversity policy and management.
+
+  <p><b>Location:</b><br>
+  $if(geraardsbergen)$
+  INBO Geraardsbergen<br>Gaverstraat 4, 9500 Geraardsbergen, Belgium
+  $else$
+  INBO Brussels<br>VAC Brussel - Herman Teirlinck, Havenlaan 88 bus 73, 1000 Brussels, Belgium
+  $endif$
+  <br><a href="https://www.vlaanderen.be/inbo/en-gb">https://www.vlaanderen.be/inbo/en-gb</a>
+
+  <p><b>e-mail:</b><br><a class="author_email" href="mailto:#">$if(corresponding)$$corresponding$$else$info@inbo.be$endif$</a>
+
+  <p><b>Way of quoting:</b><br>
+  $if(shortauthor)$
+    $shortauthor$
+  $else$
+    <h1 class = "missing">!!!! MISSING: shortauthor !!!!</h1>
+  $endif$
+  $if(year)$
+    ($year$).
+  $else$
+    <h1 class = "missing">!!!! MISSING: year !!!!</h1>
+  $endif$
+  $title$$if(subtitle)$. $substitle$$endif$. Reports of the Research Institute for Nature and Forest
+  $if(year)$
+    $year$
+  $endif$
+  $if(reportnr)$
+    ($reportnr$).
+  $else$
+    <h1 class = "missing">!!!! MISSING: reportnr !!!!</h1>
+  $endif$
+  Research Institute for Nature and Forest, Brussels. DOI:
+  $if(doi)$
+    <a class="doi" href="#">$doi$</a>
+  $else$
+    <h1 class = "missing">!!!! MISSING: doi !!!!</h1>
+  $endif$
+  <br>Export reference to <button onclick="display_export('bibtex')" style = "color: #4183c4; background: #fff; border-width: 0px;">BibTex</button>
+  <button onclick="display_export('RIS')" style = "color: #4183c4; background: #fff; border-width: 0px;">RIS</button>
+  <button onclick="display_export('csl')" style = "color: #4183c4; background: #fff; border-width: 0px;">CSL-JSON</button>
+
+<script>
+function display_export(id) {
+  var x = document.getElementById(id);
+  if (x.style.display === "none") {
+    x.style.display = "block";
+  } else {
+    x.style.display = "none";
+  }
+}
+</script>
+
+<pre id = "bibtex" style ="display: none;">
+@TechReport{
+  author= {$for(author)$$if(author.name)$$author.name$$if(author.firstname)$, $author.firstname$$endif$$else$$author$$endif$$sep$ and $endfor$},
+  title = {$title$$if(subtitle)$. $subtitle$$endif$},
+  institution = {Research Institute for Nature and Forest},
+  adress = {$if(geraardsbergen)$Geraardsbergen$else$Brussels$endif$, Belgium},
+  year = {$year$},
+  number = {$year$ ($reportnr$)},
+  doi = {$doi$},
+  type = {techreport}
+}
+</pre>
+
+<pre id = "RIS" style ="display: none;">
+TY  - RPRT
+$for(author)$AU  - $if(author.name)$$author.name$$if(author.firstname)$, $author.firstname$$endif$$else$$author$$endif$$sep$ <br>$endfor$
+TI  - $title$$if(subtitle)$. $subtitle$$endif$
+DO  - $doi$
+PB  - Research Institute for Nature and Forest
+PP  - $if(geraardsbergen)$Geraardsbergen$else$Brussels$endif$, Belgium
+PY  - $year$
+SN  - 1782-9054
+ER  -
+</pre>
+
+<pre id = "csl" style ="display: none;">
+{
+  "id":"$for(author)$$if(author.name)$$author.name$$else$$author$$endif$$endfor$$year$",
+  "type":"report",
+  "title":"$title$$if(subtitle)$. $subtitle$$endif$",
+  "author":[
+    $for(author)${
+      "family":"$if(author.name)$$author.name$$if(author.firstname)$",
+      "given":"$author.firstname$$endif$$else$$author$$endif$"
+    $sep$},
+    $endfor$
+    }
+  ],
+  "issued":{"date-parts":[[$year$]]},
+  "publisher":"Research Institute for Nature and Forest",
+  "publisher-place":"$if(geraardsbergen)$Geraardsbergen$else$Brussels$endif$, Belgium",
+}
+</pre>
+
+  $if(depotnr)$
+    <p><b>$depotnr$</b><br>
+  $else$
+    <h1 class = "missing">!!!! MISSING: depotnr !!!!</h1>
+  $endif$
+  <b>Reports of the Research Institute for Nature and Forest
+  $if(year)$
+    $year$
+  $endif$
+  $if(reportnr)$
+    ($reportnr$)
+  $endif$
+  </b><br>
+  <b>ISSN: 1782‐9054</b>
+
+  <p><b>Responsible publisher:</b><br>Maurice Hoffmann
+
+  $if(cover_description)$
+    <p><b>Cover photo:</b><br>$cover_description$
+  $else$
+    <h1 class = "missing">!!!! MISSING: cover_description !!!!</h1>
+  $endif$
+
+  $if(client)$
+  <p><b>This study was commissioned by:</b><br>
+     $for(client)$
+        $client$
+     $sep$ <br>
+     $endfor$
+     $if(client_logo)$
+       <br><img src="$url$$client_logo$" class = "client">
+     $endif$
+  $endif$
+
+  $if(cooperation)$
+  <p><b>This study was conducted in collaboration with:</b><br>
+     $for(cooperation)$
+        $cooperation$
+     $sep$ <br>
+     $endfor$
+     $if(cooperation_logo)$
+       <br><img src="$url$$cooperation_logo$" class = "client">
+     $endif$
+  $endif$
+
+  <p><a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="$csspath$/img/cc-by.svg" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
+  </div>
+$endif$
+<!--bookdown:title:end-->
+
+<!--bookdown:toc:start-->
+  <div class="book without-animation with-summary font-size-2 font-family-1" data-basepath=".">
+
+    <div class="book-summary">
+$if(cover_image)$
+<a href=".">
+<img src="$url$$cover_image$" class = "thumbnail" alt = "$shortauthor$ ($year$) $title$">
+</a><br>
+$endif$
+$if(doi)$<a class="chapter" href="#">$doi$</a>$endif$
+<br><a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons-License" style="border-width:0" src="$csspath$/img/cc-by.svg" class = "cc"/>
+      <nav role="navigation">
+<!--bookdown:toc2:start-->
+$if(toc)$
+$toc$
+$endif$
+<!--bookdown:toc2:end-->
+      </nav>
+    </div>
+
+    <div class="book-body">
+      <div class="body-inner">
+        <div class="book-header" role="navigation">
+          <h1>
+            <i class="fa fa-circle-o-notch fa-spin"></i><a href="$if(book-url)$$book-url$$else$./$endif$">$if(title)$$title$$endif$</a>
+          </h1>
+        </div>
+
+        <div class="page-wrapper" tabindex="-1" role="main">
+          <div class="page-inner">
+
+            <section class="normal" id="section-">
+$for(include-before)$
+$include-before$
+$endfor$
+<!--bookdown:toc:end-->
+<!--bookdown:body:start-->
+$body$
+
+<!--bookdown:body:end-->
+$for(include-after)$
+$include-after$
+$endfor$
+<p>&nbsp;</p>
+<p><a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons-License" style="border-width:0" src="$csspath$/img/cc-by.svg" class = "cc"/>
+$shortauthor$ ($year$). $doi$
+            </section>
+        </div>
+      </div>
+    </div>
+<!--bookdown:link_prev-->
+<!--bookdown:link_next-->
+  </div>
+<!--bookdown:config-->
+
+$if(math)$
+<!-- dynamically load mathjax for compatibility with self-contained -->
+<script>
+  (function () {
+    var script = document.createElement("script");
+    script.type = "text/javascript";
+    var src = "$if(mathjax)$$mathjax$$endif$";
+    if (src === "" || src === "true") src = "https://cdn.bootcss.com/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML";
+    if (location.protocol !== "file:" && /^https?:/.test(src))
+      src = src.replace(/^https?:/, "");
+    script.src = src;
+    document.getElementsByTagName("head")[0].appendChild(script);
+  })();
+</script>
+$endif$
+
+</body>
+
+</html>

--- a/inst/template/report_fr.html
+++ b/inst/template/report_fr.html
@@ -160,19 +160,19 @@ $if(title)$
   <h1 class = "missing">!!!! MISSING: reviewer !!!!</h1>
   $endif$
 
-  <p>The Research Institute for Nature and Forest (INBO) is an independent research institute of the Flemish government. Through applied scientific research, open data and knowledge, integration and disclosure, it underpins and evaluates biodiversity policy and management.
+  <p>l'Institut de Recherche des Forêts et de la Nature ('Instituut voor Natuur- en Bosonderzoek', INBO) est un institut de recherche indépendant du gouvernement flamand. Grâce à la recherche scientifique appliquée, aux données ouvertes et connaissances, à l'intégration et à la divulgation, elle étaye et évalue la politique et la gestion de la biodiversité.
 
-  <p><b>Location:</b><br>
+  <p><b>Emplacement:</b><br>
   $if(geraardsbergen)$
-  INBO Geraardsbergen<br>Gaverstraat 4, 9500 Geraardsbergen, Belgium
+  INBO Geraardsbergen<br>Gaverstraat 4, 9500 Geraardsbergen (Grammont), Belgique
   $else$
-  INBO Brussels<br>VAC Brussel - Herman Teirlinck, Havenlaan 88 bus 73, 1000 Brussels, Belgium
+  INBO Bruxelles<br>VAC Brussel - Herman Teirlinck, Havenlaan 88 bus 73, 1000 Bruxelles, Belgium
   $endif$
   <br><a href="https://www.vlaanderen.be/inbo/en-gb">https://www.vlaanderen.be/inbo/en-gb</a>
 
   <p><b>e-mail:</b><br><a class="author_email" href="mailto:#">$if(corresponding)$$corresponding$$else$info@inbo.be$endif$</a>
 
-  <p><b>Way of quoting:</b><br>
+  <p><b>Citation recommandée:</b><br>
   $if(shortauthor)$
     $shortauthor$
   $else$
@@ -183,7 +183,7 @@ $if(title)$
   $else$
     <h1 class = "missing">!!!! MISSING: year !!!!</h1>
   $endif$
-  $title$$if(subtitle)$. $substitle$$endif$. Reports of the Research Institute for Nature and Forest
+  $title$$if(subtitle)$. $substitle$$endif$. Rapports de l'Institut de Recherche des Forêts et de la Nature
   $if(year)$
     $year$
   $endif$
@@ -192,7 +192,7 @@ $if(title)$
   $else$
     <h1 class = "missing">!!!! MISSING: reportnr !!!!</h1>
   $endif$
-  Research Institute for Nature and Forest, Brussels. DOI:
+  l'Institut de Recherche des Forêts et de la Nature, Bruxelles. DOI:
   $if(doi)$
     <a class="doi" href="#">$doi$</a>
   $else$
@@ -272,16 +272,16 @@ ER  -
   </b><br>
   <b>ISSN: 1782‐9054</b>
 
-  <p><b>Responsible publisher:</b><br>Maurice Hoffmann
+  <p><b>Éditeur responsable:</b><br>Maurice Hoffmann
 
   $if(cover_description)$
-    <p><b>Cover photo:</b><br>$cover_description$
+    <p><b>Photo de couverture:</b><br>$cover_description$
   $else$
     <h1 class = "missing">!!!! MISSING: cover_description !!!!</h1>
   $endif$
 
   $if(client)$
-  <p><b>This study was commissioned by:</b><br>
+  <p><b>Cette étude a été commandée par:</b><br>
      $for(client)$
         $client$
      $sep$ <br>
@@ -292,7 +292,7 @@ ER  -
   $endif$
 
   $if(cooperation)$
-  <p><b>This study was conducted in collaboration with:</b><br>
+  <p><b>Cette étude a été menée en collaboration avec:</b><br>
      $for(cooperation)$
         $cooperation$
      $sep$ <br>
@@ -302,7 +302,7 @@ ER  -
      $endif$
   $endif$
 
-  <p><a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="$csspath$/img/cc-by.svg" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
+  <p><a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="$csspath$/img/cc-by.svg" /></a><br />Ce rapport est sous license <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
   </div>
 $endif$
 <!--bookdown:title:end-->


### PR DESCRIPTION
This PR aims to fix a bug that occurs while building a report in language French.  I tried adding French language for the different report formats, I am willing to expand it to other formats (poster, presentation, minutes,...) if the additions are appreciated.

I looked up the [rules for international communication](https://overheid.vlaanderen.be/internationale-communicatie):
- for the flemish logo, the English logo should be used in other languages as well
- the INBO logo should be translated (but for now I only made a French version of the flemish style, I'm not sure how logo's are produced?).  For the naming of INBO, I used the french translation supplied by the above website.

Basically I made French versions of the 'Flanders' report templates, in which I translated everything in the colofon that seemed appropriate.  In the suggested citation I also translated 'reports of the Research Institute for Nature and forest', I don't know if this is appropriate?  (Only for the report itself which is in French, I didn't change this for the reference list, so here references to reports will be in English.)  I additionally made the french version link to the French website of the flemish government (INBO has no French site, so I kept the link to the English website there).
Furthermore I adapted functions `ebook()`, `gitbook()` and `report()` in such way that option `lang = "fr"` would pass without errors and end in producing the right report.