### PR TITLE
Update website inbo

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: INBOmd
 Title: Markdown Templates for INBO
-Version: 0.5.1
+Version: 0.5.2
 Authors@R: c(
     person("Thierry", "Onkelinx", , "thierry.onkelinx@inbo.be", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-8804-4216")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# INBOmd 0.5.2
+
+* Colofon of reports now mention website 'www.inbo.be' instead of
+  'https://www.vlaanderen.be/inbo', conform with Word template.
+
 # INBOmd 0.5.1
 
 * Add language french for style Flanders

--- a/inst/local_tex/tex/latex/inborapport_2015/flanders_report_generic.sty
+++ b/inst/local_tex/tex/latex/inborapport_2015/flanders_report_generic.sty
@@ -583,7 +583,7 @@
 
     \cfmission
 
-    \textbf{\cflocation} \\ INBO \chooseestablishment{\@establishment} \\ \url{https://www.vlaanderen.be/inbo}
+    \textbf{\cflocation} \\ INBO \chooseestablishment{\@establishment} \\ \url{www.inbo.be}
 
     \textbf{e-mail:} \\ \@corresponding
 

--- a/inst/local_tex/tex/latex/inborapport_2015/inbo_report.sty
+++ b/inst/local_tex/tex/latex/inborapport_2015/inbo_report.sty
@@ -13,7 +13,7 @@
 \pagestyle{fancy}
 \fancyhead{}
 \fancyfoot{}
-\fancyfoot[LO, RE]{{\color{main.colour}\fontsize{\fontsizefooter}{\fontsizefooterinter}\selectfont \mainColourURL{\href{https://www.vlaanderen.be/inbo}{www.vlaanderen.be/inbo}}}}
+\fancyfoot[LO, RE]{{\color{main.colour}\fontsize{\fontsizefooter}{\fontsizefooterinter}\selectfont \mainColourURL{\href{https://www.inbo.be}{www.inbo.be}}}}
 \fancyfoot[LE, RO]{{\color{main.colour}\fontsize{\fontsizefooter}{\fontsizefooterinter}\selectfont Pagina \textbf{\thepage} van \textbf{\pageref*{LastPage}}}}
 \fancyfoot[CE, CO]{{\color{main.colour}\fontsize{\fontsizefooter}{\fontsizefooterinter}\selectfont \mainColourURL{\@doi}}}
 \renewcommand{\footrule}{\vbox to 8pt{\hbox
@@ -24,7 +24,7 @@ to\headwidth{\color{main.colour}\fontsize{\fontsizefooter}{\fontsizefooterinter}
 \fancypagestyle{plain}{%
   \fancyhead{}
   \fancyfoot{}
-  \fancyfoot[LO, RE]{{\color{main.colour}\fontsize{\fontsizefooter}{\fontsizefooterinter}\selectfont \mainColourURL{\href{https://www.vlaanderen.be/inbo}{www.vlaanderen.be/inbo}}}}
+  \fancyfoot[LO, RE]{{\color{main.colour}\fontsize{\fontsizefooter}{\fontsizefooterinter}\selectfont \mainColourURL{\href{https://www.inbo.be}{www.inbo.be}}}}
   \fancyfoot[CE, CO]{{\color{main.colour}\fontsize{\fontsizefooter}{\fontsizefooterinter}\selectfont \mainColourURL{\@doi}}}
   \fancyfoot[LE, RO]{{\color{main.colour}\fontsize{\fontsizefooter}{\fontsizefooterinter}\selectfont Pagina \textbf{\thepage} van \textbf{\pageref*{LastPage}}}}
   \renewcommand{\headrulewidth}{0pt}
@@ -35,7 +35,7 @@ to\headwidth{\color{main.colour}\fontsize{\fontsizefooter}{\fontsizefooterinter}
   \fancyhead{}
   \fancyfoot{}
   \fancyfoot[L]{\includegraphics[height = 10mm, keepaspectratio]{vlaanderen-nl-naakt}}
-  \fancyfoot[R]{{\color{main.colour}\fontsize{\fontsizefooter}{\fontsizefooterinter}\selectfont www.vlaanderen.be/inbo}}
+  \fancyfoot[R]{{\color{main.colour}\fontsize{\fontsizefooter}{\fontsizefooterinter}\selectfont www.inbo.be}}
   \renewcommand{\headrulewidth}{0pt}
   \renewcommand{\footrulewidth}{0pt}
   \renewcommand{\footrule}{\vbox to 0pt{\hbox

--- a/inst/template/report_en.epub3
+++ b/inst/template/report_en.epub3
@@ -104,7 +104,7 @@ $if(titlepage)$
   $else$
   INBO Brussel<br>Herman Teirlinckgebouw, Havenlaan 88 bus 73, 1000 Brussel, Belgium
   $endif$
-  <br><a href="https://www.vlaanderen.be/inbo/en-gb">https://www.vlaanderen.be/inbo/en-gb</a>
+  <br><a href="https://www.inbo.be/en">www.inbo.be/en</a>
 
   <p><b>e-mail:</b><br><a class="author_email" href="mailto:#">$if(corresponding)$$corresponding$$else$info@inbo.be$endif$</a>
 

--- a/inst/template/report_fr.epub3
+++ b/inst/template/report_fr.epub3
@@ -104,7 +104,7 @@ $if(titlepage)$
   $else$
   INBO Brussel<br>Herman Teirlinckgebouw, Havenlaan 88 bus 73, 1000 Brussel, Belgique
   $endif$
-  <br><a href="https://www.vlaanderen.be/inbo/en-gb">https://www.vlaanderen.be/inbo/en-gb</a>
+  <br><a href="https://www.inbo.be/en">https://www.inbo.be/en</a>
 
   <p><b>e-mail:</b><br><a class="author_email" href="mailto:#">$if(corresponding)$$corresponding$$else$info@inbo.be$endif$</a>
 

--- a/inst/template/report_nl.epub3
+++ b/inst/template/report_nl.epub3
@@ -104,7 +104,7 @@ $if(titlepage)$
   $else$
     INBO Brussel<br>Herman Teirlinckgebouw, Havenlaan 88 bus 73, 1000 Brussel
   $endif$
-  <br><a href="https://www.vlaanderen.be/inbo">https://www.vlaanderen.be/inbo</a>
+  <br><a href="https://www.inbo.be">www.inbo.be</a>
 
   <p><b>e-mail:</b><br><a class="author_email" href="mailto:#">$if(corresponding)$$corresponding$$else$info@inbo.be$endif$</a>
 

--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -19,7 +19,7 @@ knitr::opts_chunk$set(
 # Goal
 
 The `INBOmd` package provides several styles for [`rmarkdown`](https://rmarkdown.rstudio.com/) files.
-The styles are based on the corporate identity of the Research Institute for Nature and Forest (Instituut voor Natuur en Bosonderzoek, [INBO](https://www.vlaanderen.be/inbo/en-gb/)).
+The styles are based on the corporate identity of the Research Institute for Nature and Forest (Instituut voor Natuur en Bosonderzoek, [INBO](https://www.inbo.be/en/)).
 The styles itself are not intended for use by parties external to INBO.
 We still provide them to other users as an inspiration and example on how to create their own corporate identity styles for `rmarkdown` files. 
 


### PR DESCRIPTION
This PR changes the website 'https://www.vlaanderen.be/inbo' by 'www.inbo.be' in the report colofon, to make the INBOmd template similar to the Word templates, as described in issue  #81.

In other non INBOmd templates, 'www.vlaanderen.be/inbo' is still used, except for the small screen view of the Google Slides template, where 'www.inbo.be' is used.  (For slideshows, templates also exist for wide screen view for Google Slides and for MS Powerpoint.)  That's why I decided to only change it in reports.