### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,14 @@ Below are some documents created with INBOmd
 
 ## Installation
 
-INBOmd requires a working installation of XeLaTeX.
-We highly recommend to use the TinyTeX.
+INBOmd requires a working LaTeX distribution (for conversion of markdown
+to pdf).
+We highly recommend to use the LaTeX distribution provided by R
+package TinyTeX.
 Close all open R sessions and start a fresh R session.
 Execute the commands below.
-This will install TinyTeX on your machine.
+This will install the R package TinyTeX and the TinyTex LaTeX distribution
+on your machine.
 No admin rights are required.
 Although TinyTeX is a lightweight installation, it still is several 100 MB large.
 
@@ -46,6 +49,7 @@ update.packages(ask = FALSE, checkBuilt = TRUE)
 if (!"tinytex" %in% rownames(installed.packages())) {
   install.packages("tinytex")
 }
+# install the TinyTeX LaTeX distribution
 if (!tinytex:::is_tinytex()) {
   tinytex::install_tinytex()
 }
@@ -55,15 +59,23 @@ Once TinyTeX is installed, you need to restart RStudio.
 Then you can proceed with the installation of `INBOmd`.
 
 ```
-if (!"remotes" %in% rownames(installed.packages())) {
-  install.packages("remotes")
-}
-remotes::install_github("inbo/INBOmd", dependencies = TRUE)
-tinytex::tlmgr_install(c(
-  'inconsolata', 'times', 'tex', 'helvetic', 'dvips'
-))
+# installation from inbo.r-universe
+install.packages("INBOmd", repos = "https://inbo.r-universe.dev")
+
+## alternative: installation from github
+#if (!"remotes" %in% rownames(installed.packages())) {
+#  install.packages("remotes")
+#}
+#remotes::install_github("inbo/INBOmd", dependencies = TRUE)
+
+# add the local latex package contained in INBOmd to the TinyTeX install 
 tinytex::tlmgr_conf(
   c("auxtrees", "add", system.file("local_tex", package = "INBOmd"))
 )
-tinytex::tlmgr_install(c("hyphen-dutch", "hyphen-french"))
+
+# install some other needed latex packages 
+tinytex::tlmgr_install(c(
+  "inconsolata", "times", "tex", "helvetic", "dvips", "hyphen-dutch",
+  "hyphen-french"
+))
 ```


### PR DESCRIPTION
Update of installation instructions. 

Regarding the step "install some other needed latex packages " I wonder if this can be skipped or rather whether the list of needed packages should be extended. 
Skipping the step would postpone the installation of these packages to the first time an INBOmd report is build to PDF (???). On the other hand, this will add to an already long list of LaTeX packages that will be installed on the fly (`mdframed, zref, needspace, marginnote, babel, babel, babel, carlisle, eurosym, upquote, wrapfig, colortbl, pdflscape, tabu, varwidth, threeparttable, threeparttablex, environ, trimspaces, makecell, footmisc, tocloft, titlesec, ulem, lastpage, fancyhdr, emptypage, placeins, parskip, eso, grfext, oberdiek, pdfpages`[*]) and this seems quite a brittle process given I had some trouble with the LaTeX mirror being too slow or not responding. So maybe it's better to explicitly include all of them in the installation instructions?

I used inbo.r-universe for preferred way to install INBOmd.
I also moved the installation of LaTeX packages into one command call as I didn't saw a reason to split it over two calls (but maybe there is, so please check).

[*] note that these packages are the ones that get installed when building the unaltered template provided by INBOmd for a report 