### PR TITLE
Security: GitHub Actions pinnen op volledige commit-SHA

### DIFF
--- a/.github/workflows/check_on_different_r_os.yml
+++ b/.github/workflows/check_on_different_r_os.yml
@@ -32,20 +32,20 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
-      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: ${{ matrix.config.r }}
           extra-repositories: https://inbo.r-universe.dev
 
-      - uses: r-lib/actions/setup-pandoc@v2
+      - uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      - uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           extra-packages: any::rcmdcheck
           needs: check
 
-      - uses: r-lib/actions/check-r-package@v2
+      - uses: r-lib/actions/check-r-package@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           error-on: '"error"'

--- a/.github/workflows/check_package.yaml
+++ b/.github/workflows/check_package.yaml
@@ -16,7 +16,7 @@ jobs:
       contents: read
     steps:
       - name: "Check package with checklist"
-        uses: inbo/actions/check_pkg@a29089fc9a2ea38b9d9bd62c0d1db3b448b224c8 # composite
+        uses: inbo/actions/check_pkg@composite
   deploy-pages:
     name: deploy-gh-pages
     runs-on: ubuntu-24.04
@@ -26,4 +26,4 @@ jobs:
       contents: write
     steps:
       - name: "Tag and deploy gh-pages"
-        uses: inbo/actions/check_deploy@a29089fc9a2ea38b9d9bd62c0d1db3b448b224c8 # composite
+        uses: inbo/actions/check_deploy@composite

--- a/.github/workflows/check_package.yaml
+++ b/.github/workflows/check_package.yaml
@@ -16,7 +16,7 @@ jobs:
       contents: read
     steps:
       - name: "Check package with checklist"
-        uses: inbo/actions/check_pkg@composite
+        uses: inbo/actions/check_pkg@a29089fc9a2ea38b9d9bd62c0d1db3b448b224c8 # composite
   deploy-pages:
     name: deploy-gh-pages
     runs-on: ubuntu-24.04
@@ -26,4 +26,4 @@ jobs:
       contents: write
     steps:
       - name: "Tag and deploy gh-pages"
-        uses: inbo/actions/check_deploy@composite
+        uses: inbo/actions/check_deploy@a29089fc9a2ea38b9d9bd62c0d1db3b448b224c8 # composite

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -16,7 +16,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: build examples
-        uses: inbo/actions/render_inbomd@55098124f283c4f9b9402d43ec4a9382ee05c105 # devel
+        uses: inbo/actions/render_inbomd@devel
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EXAMPLE_BRANCH: main

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -14,9 +14,9 @@ jobs:
     name: "test Rmd"
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: build examples
-        uses: inbo/actions/render_inbomd@devel
+        uses: inbo/actions/render_inbomd@55098124f283c4f9b9402d43ec4a9382ee05c105 # devel
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EXAMPLE_BRANCH: main


### PR DESCRIPTION
_Onderdeel van een INBO-brede security-hardening: SHA-pinning van GitHub Actions. Aanbevolen door o.a. [GitHub Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)._